### PR TITLE
Issue #7: Init script to run right after the first user is registered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,19 @@ This document contains changes of the project in reverse chronological order
 
 ## upcoming
 
-Need to add authorization for both controllers
+Policies to check if the user is root or admin (issue #6)
 
 Use bootstrap layout for Post and Category controllers
-
-Init controller for the situation when there is no root at the system
 
 Develop front page
 
 Wysiwyg-editor for post editing
+
+## 2019-12-29
+
+Added authorization for Post and Category controllers - allowed only for admins. Access to Role and User controllers is allowed only for users in the role of root.
+
+Added Init controller for the situations when the application is deployed with empty database. Resolves issue #7
 
 ## 2019-12-22
 

--- a/Controllers/InitController.cs
+++ b/Controllers/InitController.cs
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Identity;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+
+namespace pspbe.Controllers
+{
+    [Authorize]
+    public class InitController : Controller
+    {
+        private RoleManager<IdentityRole> _roleManager { get; }
+        private UserManager<IdentityUser> _userManager { get; }
+        public InitController(RoleManager<IdentityRole> roleManager, UserManager<IdentityUser> userManager)
+        {
+            _roleManager = roleManager;
+            _userManager = userManager;
+        }
+        public async Task<IActionResult> Index()
+        {
+            // If root role already exists in the system, return 404 
+            if (await _roleManager.RoleExistsAsync("root"))
+            {
+                var notFoundObject = new NotFoundObjectResult(this.NotFound());
+                return NotFound();
+            }
+            // Create root and admin roles and assign them to the current user
+            List<string> rolesList = new List<string>();
+            IdentityResult rootResult = await _roleManager.CreateAsync(new IdentityRole("root"));
+                if (rootResult.Succeeded == true)
+                {
+                    rolesList.Add("root");
+                    IdentityResult adminResult = await _roleManager.CreateAsync(new IdentityRole("admin"));
+                    if (adminResult.Succeeded == true)
+                    {
+                        rolesList.Add("admin");
+                        var currentUser = await _userManager.GetUserAsync(User);
+                        await _userManager.AddToRolesAsync(currentUser, rolesList);
+                    }
+                }
+            return RedirectToAction("Index", "Home");
+        }
+    }
+}

--- a/Controllers/RoleController.cs
+++ b/Controllers/RoleController.cs
@@ -2,10 +2,12 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using pspbe.Data;
 
 namespace pspbe.Controllers
 {
+    [Authorize(Roles = "root")]
 public class RoleController : Controller
 {
     RoleManager<IdentityRole> _roleManager;

--- a/Controllers/UserController.cs
+++ b/Controllers/UserController.cs
@@ -6,7 +6,7 @@ using pspbe.Data;
 
 namespace pspbe.Controllers
 {
-    //[Authorize(Roles = "root")]
+    [Authorize(Roles = "root")]
     public class UserController : Controller
     {
         UserManager<IdentityUser> _userManager;

--- a/Startup.cs
+++ b/Startup.cs
@@ -31,7 +31,7 @@ namespace pspbe
             services.AddDbContext<ApplicationDbContext>(options =>
                 options.UseMySql(
                     Configuration.GetConnectionString("MySqlConnection")));
-            services.AddDefaultIdentity<IdentityUser>(options => options.SignIn.RequireConfirmedAccount = true)
+            services.AddDefaultIdentity<IdentityUser>(options => options.SignIn.RequireConfirmedAccount = false)
                 .AddRoles<IdentityRole>()
                 .AddEntityFrameworkStores<ApplicationDbContext>();
             services.AddDbContext<BlogDbContext>(options =>


### PR DESCRIPTION
These changes resolve issue #7. After the app is first deployed and all migrations are executed, the database does not contains users and roles. The first user registers himself with standard registration procedure. Then he logs in and becomes able to run init script. After successful execution of the script the user gets roles of root and admin. 